### PR TITLE
Core Auth Configuration

### DIFF
--- a/core-auth-fe/CHANGELOG.md
+++ b/core-auth-fe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @groovestack/auth
 
+## 0.2.22
+
+### Patch Changes
+
+- email form is rendered conditionally based off configured auth providers in app config
+
 ## 0.2.21
 
 ### Patch Changes

--- a/core-auth-fe/package.json
+++ b/core-auth-fe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@groovestack/auth",
   "title": "CORE Auth",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "React-admin custom login flow that supports email/password as well as Oauth (Google & Apple) out of the box.",
   "homepage": "https://talysto.com/groovestack/#core-auth",
   "keywords": [

--- a/core-auth-fe/src/core-auth/components/login-mui/LoginPanel.tsx
+++ b/core-auth-fe/src/core-auth/components/login-mui/LoginPanel.tsx
@@ -12,6 +12,7 @@ interface Props {
   ctaDisabled?: boolean
   onLogin?: React.FormEventHandler<HTMLFormElement> | undefined
   onRegister?: React.FormEventHandler<HTMLFormElement> | undefined
+  providers?: string[]
   social?: SocialSignInProps['social']
   socialSignInRender?: SocialSignInProps['renderButton']
   onClickSocialConnect?: Function
@@ -29,6 +30,7 @@ export function LoginPanel({
   onLogin,
   onRegister,
   onPasswordReset,
+  providers,
   social,
   socialSignInRender,
   ctaDisabled = false,
@@ -41,28 +43,32 @@ export function LoginPanel({
     setValue(newValue)
   }
 
+  const emailProviderEnabled = providers?.includes('email')
+
   return (
     <Paper sx={{ margin: { xs: 0 }, minHeight: 425, display: 'flex', flexDirection: 'column' }}>
-      <TabContext value={value}>
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <TabList centered onChange={handleChange} aria-label="Login or Signup">
-            <Tab label="Login" value="1" disabled={!login} />
-            {registration && <Tab label="Sign Up" value="2" />}
-          </TabList>
-        </Box>
-          <TabPanel value="1">
-            <LoginForm
-              ctaDisabled={ctaDisabled}
-              onSubmit={onLogin}
-              onPasswordReset={onPasswordReset}
-            />
-          </TabPanel>
-        {registration && (
-          <TabPanel value="2">
-            <SignupForm onSubmit={onRegister} />
-          </TabPanel>
-        )}
-      </TabContext>
+      {emailProviderEnabled && (
+        <TabContext value={value}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <TabList centered onChange={handleChange} aria-label="Login or Signup">
+              <Tab label="Login" value="1" disabled={!login} />
+              {registration && <Tab label="Sign Up" value="2" />}
+            </TabList>
+          </Box>
+            <TabPanel value="1">
+              <LoginForm
+                ctaDisabled={ctaDisabled}
+                onSubmit={onLogin}
+                onPasswordReset={onPasswordReset}
+              />
+            </TabPanel>
+          {registration && (
+            <TabPanel value="2">
+              <SignupForm onSubmit={onRegister} />
+            </TabPanel>
+          )}
+        </TabContext>
+      )}
       <SocialSignIn renderButton={socialSignInRender} social={social} />
     </Paper>
   )

--- a/core-auth-fe/src/core-auth/react-admin/LoginPage/index.tsx
+++ b/core-auth-fe/src/core-auth/react-admin/LoginPage/index.tsx
@@ -86,6 +86,7 @@ export const LoginPage = (props: LoginPageProps) => {
   const serverURLParamsHandled = useHandleServerURLParams()
 
   const [socials, setSocials] = useState<SocialSignInProps['social']>([])
+  const [providers, setProviders] = useState<string[]>([])
   let { backgroundImage, credentials = defaultCredentials, Headline = AppInitHeadline, ...rest } = props
   const containerRef = useRef<HTMLDivElement | null>(null)
   let backgroundImageLoaded = false
@@ -229,12 +230,15 @@ export const LoginPage = (props: LoginPageProps) => {
   })
 
   useEffect(() => {
-    const social = credentials.getAppConfig()?.oauth_providers?.enabled.map((p: OauthProvider) => {
+    const appConfig = credentials.getAppConfig()
+    const social = appConfig?.oauth_providers?.configured.map((p: OauthProvider) => {
       const { k, path: href } = p
       return { k, href }
     })
-
     setSocials(social || [])
+
+    const providers = appConfig?.auth_providers?.configured.map((p: OauthProvider) => p.k)
+    setProviders(providers || [])
   }, [])
 
   useEffect(notifyOmniauthFailureError, [serverURLParamsHandled])
@@ -253,6 +257,7 @@ export const LoginPage = (props: LoginPageProps) => {
         <LoginPanel
           social={socials}
           socialSignInRender={socialSignInRender}
+          providers={providers}
           onLogin={onLogin}
           onRegister={onRegister}
           registration={true}

--- a/core-auth/config/initializers/core_config.rb
+++ b/core-auth/config/initializers/core_config.rb
@@ -7,10 +7,22 @@ ActiveSupport.on_load(:after_initialize) do
       key: :oauth_providers, 
       build: Proc.new { 
         { 
-          available: Core::Auth::Providers::OmniAuth.available_providers.map { |p| p.as_json[:k] }, 
-          enabled: Core::Auth::Providers::OmniAuth.enabled_providers.map { |p| p.as_json([:k, :path]) }
+          available: Core::Auth.available_providers(ancestor: Core::Auth::Providers::OmniAuth).map { |p| p.as_json[:k] }, 
+          enabled: Core::Auth.enabled_providers(ancestor: Core::Auth::Providers::OmniAuth).map { |p| p.as_json([:k, :path]) },
+          configured: Core::Auth.configured_providers(ancestor: Core::Auth::Providers::OmniAuth).map { |p| p.as_json([:k, :provider, :path]) }
         } 
       } 
+    }
+
+    Core::Config::App.dynamic_config << {
+      key: :auth_providers,
+      build: Proc.new {
+        {
+          available: Core::Auth.available_providers.map { |p| p.as_json([:k, :provider]) },
+          enabled: Core::Auth.enabled_providers.map { |p| p.as_json([:k, :provider, :path]) },
+          configured: Core::Auth.configured_providers.map { |p| p.as_json([:k, :provider, :path]) }
+        }
+      }
     }
 
     # make AppConfig query public

--- a/core-auth/config/initializers/omniauth.rb
+++ b/core-auth/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  Core::Auth::Providers::OmniAuth.enabled_providers.each do |p|
+  Core::Auth.configured_providers(ancestor: Core::Auth::Providers::OmniAuth).each do |p|
     provider *p.generate_omniauth_args
   end
 end

--- a/core-auth/core-auth.gemspec
+++ b/core-auth/core-auth.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency "dry-configurable"
   spec.add_dependency 'graphql_devise', '~>1.4'
   spec.add_dependency 'omniauth-google-oauth2'
   spec.add_dependency 'omniauth-apple'

--- a/core-auth/lib/core/auth.rb
+++ b/core-auth/lib/core/auth.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
+require 'active_record'
+require 'dry-configurable'
 require 'graphql_devise'
 require 'omniauth-google-oauth2'
 require 'omniauth-apple'
 
 require 'core/auth/version'
-require 'active_record'
-
 require 'core/auth/railtie' if defined?(Rails::Railtie)
-require 'core/auth/provider'
 
 # add devise and devise_token_auth app/ dirs to load path
 Dir[File.join(Gem::Specification.find_by_name("devise").gem_dir, "app", '*')].each { |sub_dir| $LOAD_PATH.push(sub_dir) }
@@ -28,19 +27,45 @@ require 'users/roles'
 require 'user'
 require 'identity'
 
-require 'graphql/identity/type'
-require 'graphql/identity/filter'
-require 'graphql/identity/queries'
-require 'graphql/identity/mutations'
+module GraphQL
+  module Identity
+    autoload :Type, 'graphql/identity/type'
+    autoload :Filter, 'graphql/identity/filter'
+    autoload :Queries, 'graphql/identity/queries'
+    autoload :Mutations, 'graphql/identity/mutations'
+  end
 
-require 'graphql/user/filter'
-require 'graphql/user/type'
-require 'graphql/user/queries'
-require 'graphql/user/mutations'
+  module User
+    autoload :Filter, 'graphql/user/filter'
+    autoload :Type, 'graphql/user/type'
+    autoload :Queries, 'graphql/user/queries'
+    autoload :Mutations, 'graphql/user/mutations'
+  end
+end
 
-require 'core/auth/authenticated_api_controller'
-require 'core/auth/omniauth_callbacks_controller'
-require 'core/auth/action_cable'
-require 'core/auth/schema_plugin'
+module Core
+  module Auth
+    autoload :Provider, 'core/auth/provider'
+    autoload :AuthenticatedApiController, 'core/auth/authenticated_api_controller'
+    autoload :OmniauthCallbacksController, 'core/auth/omniauth_callbacks_controller'
+    autoload :ActionCable, 'core/auth/action_cable'
+    autoload :SchemaPlugin, 'core/auth/schema_plugin'
+
+    module Providers
+      extend ActiveSupport::Autoload
+
+      eager_autoload do
+        autoload :Email, 'core/auth/providers/email'
+        autoload :OmniAuth, 'core/auth/providers/omni_auth'
+        autoload :Apple, 'core/auth/providers/apple'
+        autoload :Google, 'core/auth/providers/google'
+      end
+    end
+
+    extend Dry::Configurable
+
+    setting :disabled_providers, default: [], reader: true
+  end
+end
 
 require 'test/fabricators/user_fabricator'

--- a/core-auth/lib/core/auth/providers/apple.rb
+++ b/core-auth/lib/core/auth/providers/apple.rb
@@ -1,0 +1,24 @@
+module Core
+  module Auth
+    module Providers
+      class Apple < OmniAuth
+        PROVIDER = :apple
+        REQUIRED_CREDENTIALS = [:APPLE_CLIENT_ID, :APPLE_TEAM_ID, :APPLE_KEY_ID, :APPLE_PEM_CONTENT]
+
+        def self.generate_omniauth_args 
+          [
+            provider,
+            Rails.application.credentials.APPLE_CLIENT_ID,
+            '',
+            {
+              team_id: Rails.application.credentials.APPLE_TEAM_ID,
+              key_id: Rails.application.credentials.APPLE_KEY_ID,
+              pem: Rails.application.credentials.APPLE_PEM_CONTENT,
+              origin_param: 'return_to'
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/core-auth/lib/core/auth/providers/email.rb
+++ b/core-auth/lib/core/auth/providers/email.rb
@@ -1,0 +1,13 @@
+module Core
+  module Auth
+    module Providers
+      class Email < Core::Auth::Provider
+        PROVIDER = :email
+
+        def self.configured?
+          true
+        end
+      end
+    end
+  end
+end

--- a/core-auth/lib/core/auth/providers/google.rb
+++ b/core-auth/lib/core/auth/providers/google.rb
@@ -1,0 +1,15 @@
+module Core
+  module Auth
+    module Providers
+      class Google < OmniAuth
+        PROVIDER = :google_oauth2
+        K = :google
+        REQUIRED_CREDENTIALS = [:GOOGLE_CLIENT_ID, :GOOGLE_CLIENT_SECRET]
+
+        def self.generate_omniauth_args 
+          super << { name: k, origin_param: 'return_to' }
+        end
+      end
+    end
+  end
+end

--- a/core-auth/lib/core/auth/providers/omni_auth.rb
+++ b/core-auth/lib/core/auth/providers/omni_auth.rb
@@ -1,0 +1,45 @@
+module Core
+  module Auth
+    module Providers
+      class OmniAuth < Core::Auth::Provider
+        BASE_PATH = '/users/auth'.freeze
+
+        def self.required_credentials
+          self.const_defined?(:REQUIRED_CREDENTIALS) ? self::REQUIRED_CREDENTIALS : []
+        end
+
+        def self.required_credentials_present?
+          required_credentials.all? { |credential| Rails.application.credentials.send(credential).present? }
+        end
+
+        def self.configured?
+          required_credentials_present?
+        end
+
+        def self.generate_omniauth_args 
+          # different providers require different arguments
+          [
+            provider, 
+            *required_credentials.map { |c| Rails.application.credentials.send(c) },
+          ]
+        end
+
+        def self.path
+          "#{BASE_PATH}/#{k}"
+        end
+
+        def self.as_json(keys=nil)
+          verbose = super.merge({
+            required_credentials: required_credentials,
+            path: path,
+            generate_omniauth_args: generate_omniauth_args
+          })
+  
+          return verbose if keys.nil?
+  
+          verbose.select { |k, v| keys.include?(k) }
+        end
+      end
+    end
+  end
+end

--- a/core-auth/lib/core/auth/railtie.rb
+++ b/core-auth/lib/core/auth/railtie.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'provider'
+
 if defined?(Rails)
   module Core
     module Auth
@@ -16,11 +18,21 @@ if defined?(Rails)
               eval: proc { raise unless defined?(::Core::Config) },
               message: "Error: 'core-config' gem is required, add it your your gemfile"
             },
+            # {
+            #   eval: proc { raise unless (app_config = ::Core::Config::App.generate_config) && ((app_config.keys.include?(:oauth_enabled) && !app_config[:oauth_enabled]) || ::Core::Auth::Providers::OmniAuth.enabled_providers.present? ) },
+            #   message: "Warning: oauth is enabled but no providers are configured. Follow the instructions in the README to configure oauth providers or disable oauth in the groovestack initializer."
+            # }
             {
-              eval: proc { raise unless (app_config = ::Core::Config::App.generate_config) && ((app_config.keys.include?(:oauth_enabled) && !app_config[:oauth_enabled]) || ::Core::Auth::Providers::OmniAuth.enabled_providers.present? ) },
-              message: "Warning: oauth is enabled but no providers are configured. Follow the instructions in the README to configure oauth providers or disable oauth in the groovestack initializer."
+              eval: proc { 
+                raise if ::Core::Auth.enabled_providers_sans_configuration.present? 
+              },
+              message: "\n\tWarning: enabled providers are missing required credentials:\n\t\t#{::Core::Auth.enabled_providers_sans_configuration.map { |h| "#{h.provider.to_s.titleize} - #{h.required_credentials.join(', ')}" }.join("\n\t\t")}\n\tAdd them to your credentials file or disable the providers by adding them to Core::Auth.disabled_providers."
             }
           ]
+        end
+
+        def module_description
+          "\n\tAvailable auth providers: #{::Core::Auth.available_providers.map(&:k).map(&:to_s).map(&:titleize).join(', ')}\n\tEnabled auth providers: #{::Core::Auth.enabled_providers.map(&:k).map(&:to_s).map(&:titleize).join(', ')}"
         end
 
         initializer :append_migrations do |app|

--- a/test-core-fe/CHANGELOG.md
+++ b/test-core-fe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # test-core-fe
 
+## 0.2.128
+
+### Patch Changes
+
+- Updated dependencies
+  - @groovestack/auth@0.2.22
+
 ## 0.2.127
 
 ### Patch Changes

--- a/test-core-fe/package.json
+++ b/test-core-fe/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-core-fe",
   "private": true,
-  "version": "0.2.127",
+  "version": "0.2.128",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
- treat email / password as auth provider
- email / password and all other auth providers can be manually disabled
- only render enabled & configure auth providers within the Login Panel